### PR TITLE
GR 3.10 type casting fix

### DIFF
--- a/examples/aprs-loopback-gui.grc
+++ b/examples/aprs-loopback-gui.grc
@@ -1,0 +1,342 @@
+options:
+  parameters:
+    author: ''
+    catch_exceptions: 'True'
+    category: Custom
+    cmake_opt: ''
+    comment: ''
+    copyright: ''
+    description: ''
+    gen_cmake: 'On'
+    gen_linking: dynamic
+    generate_options: qt_gui
+    hier_block_src_path: '.:'
+    id: aprs_loopback_gui
+    max_nouts: '0'
+    output_language: python
+    placement: (0,0)
+    qt_qss_theme: ''
+    realtime_scheduling: ''
+    run: 'True'
+    run_command: '{python} -u {filename}'
+    run_options: run
+    sizing_mode: fixed
+    thread_safe_setters: ''
+    title: ''
+    window_size: 1280, 1024
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [8, 11]
+    rotation: 180
+    state: enabled
+
+blocks:
+- name: samp_rate
+  id: variable
+  parameters:
+    comment: ''
+    value: '48000'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [8, 99]
+    rotation: 0
+    state: enabled
+- name: analog_pwr_squelch_xx_0
+  id: analog_pwr_squelch_xx
+  parameters:
+    affinity: ''
+    alias: ''
+    alpha: 1e-4
+    comment: ''
+    gate: 'True'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    ramp: '0'
+    threshold: '-100'
+    type: float
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [696, 164.0]
+    rotation: 0
+    state: true
+- name: audio_sink_0
+  id: audio_sink
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    device_name: ''
+    num_inputs: '1'
+    ok_to_block: 'True'
+    samp_rate: '48000'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [888, 60.0]
+    rotation: 0
+    state: enabled
+- name: blocks_multiply_const_vxx_0
+  id: blocks_multiply_const_vxx
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    const: '0.1'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    type: float
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [904, 116.0]
+    rotation: 0
+    state: enabled
+- name: blocks_wavfile_sink_0
+  id: blocks_wavfile_sink
+  parameters:
+    affinity: ''
+    alias: ''
+    append: 'False'
+    bits_per_sample1: FORMAT_PCM_16
+    bits_per_sample2: FORMAT_PCM_16
+    bits_per_sample3: FORMAT_VORBIS
+    bits_per_sample4: FORMAT_PCM_16
+    comment: ''
+    file: /home/vlad/Downloads/bruninga.wav
+    format: FORMAT_WAV
+    nchan: '1'
+    samp_rate: samp_rate
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1376, 36.0]
+    rotation: 0
+    state: true
+- name: bruninga_ax25_fsk_mod_0
+  id: bruninga_ax25_fsk_mod
+  parameters:
+    affinity: ''
+    alias: ''
+    baud_rate: '1200'
+    comment: ''
+    flag_count: '5'
+    mark_freq: '2200'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    preamble_len_ms: 16.0/1200*1000
+    samp_rate: samp_rate
+    space_freq: '1200'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [456, 148.0]
+    rotation: 0
+    state: enabled
+- name: bruninga_fsk_demod_0
+  id: bruninga_fsk_demod
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    samp_rate: samp_rate
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [896, 180.0]
+    rotation: 0
+    state: enabled
+- name: bruninga_hdlc_to_ax25_1
+  id: bruninga_hdlc_to_ax25
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1256, 184.0]
+    rotation: 0
+    state: enabled
+- name: bruninga_str_to_aprs_0
+  id: bruninga_str_to_aprs
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    dest: ID
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    src: KX4TH-2
+    via: '[]'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [288, 172.0]
+    rotation: 0
+    state: enabled
+- name: digital_hdlc_deframer_bp_0
+  id: digital_hdlc_deframer_bp
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    max: '500'
+    maxoutbuf: '0'
+    min: '15'
+    minoutbuf: '0'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1088, 172.0]
+    rotation: 0
+    state: enabled
+- name: network_socket_pdu_0
+  id: network_socket_pdu
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    host: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    mtu: '10000'
+    port: '52001'
+    tcp_no_delay: 'False'
+    type: TCP_SERVER
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [56, 220.0]
+    rotation: 0
+    state: true
+- name: qtgui_time_sink_x_0
+  id: qtgui_time_sink_x
+  parameters:
+    affinity: ''
+    alias: ''
+    alpha1: '1.0'
+    alpha10: '1.0'
+    alpha2: '1.0'
+    alpha3: '1.0'
+    alpha4: '1.0'
+    alpha5: '1.0'
+    alpha6: '1.0'
+    alpha7: '1.0'
+    alpha8: '1.0'
+    alpha9: '1.0'
+    autoscale: 'False'
+    axislabels: 'True'
+    color1: blue
+    color10: dark blue
+    color2: red
+    color3: green
+    color4: black
+    color5: cyan
+    color6: magenta
+    color7: yellow
+    color8: dark red
+    color9: dark green
+    comment: ''
+    ctrlpanel: 'False'
+    entags: 'True'
+    grid: 'False'
+    gui_hint: ''
+    label1: Signal 1
+    label10: Signal 10
+    label2: Signal 2
+    label3: Signal 3
+    label4: Signal 4
+    label5: Signal 5
+    label6: Signal 6
+    label7: Signal 7
+    label8: Signal 8
+    label9: Signal 9
+    legend: 'True'
+    marker1: '-1'
+    marker10: '-1'
+    marker2: '-1'
+    marker3: '-1'
+    marker4: '-1'
+    marker5: '-1'
+    marker6: '-1'
+    marker7: '-1'
+    marker8: '-1'
+    marker9: '-1'
+    name: '""'
+    nconnections: '1'
+    size: '1024'
+    srate: samp_rate
+    stemplot: 'False'
+    style1: '1'
+    style10: '1'
+    style2: '1'
+    style3: '1'
+    style4: '1'
+    style5: '1'
+    style6: '1'
+    style7: '1'
+    style8: '1'
+    style9: '1'
+    tr_chan: '0'
+    tr_delay: '0'
+    tr_level: '0.0'
+    tr_mode: qtgui.TRIG_MODE_FREE
+    tr_slope: qtgui.TRIG_SLOPE_POS
+    tr_tag: '""'
+    type: float
+    update_time: '0.10'
+    width1: '1'
+    width10: '1'
+    width2: '1'
+    width3: '1'
+    width4: '1'
+    width5: '1'
+    width6: '1'
+    width7: '1'
+    width8: '1'
+    width9: '1'
+    ylabel: Amplitude
+    ymax: '1'
+    ymin: '-1'
+    yunit: '""'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1152, 292.0]
+    rotation: 0
+    state: true
+
+connections:
+- [analog_pwr_squelch_xx_0, '0', blocks_multiply_const_vxx_0, '0']
+- [analog_pwr_squelch_xx_0, '0', bruninga_fsk_demod_0, '0']
+- [blocks_multiply_const_vxx_0, '0', audio_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', blocks_wavfile_sink_0, '0']
+- [blocks_multiply_const_vxx_0, '0', qtgui_time_sink_x_0, '0']
+- [bruninga_ax25_fsk_mod_0, '0', analog_pwr_squelch_xx_0, '0']
+- [bruninga_fsk_demod_0, '0', digital_hdlc_deframer_bp_0, '0']
+- [bruninga_str_to_aprs_0, out, bruninga_ax25_fsk_mod_0, in]
+- [digital_hdlc_deframer_bp_0, out, bruninga_hdlc_to_ax25_1, in]
+- [network_socket_pdu_0, pdus, bruninga_str_to_aprs_0, in]
+
+metadata:
+  file_format: 1
+  grc_version: 3.10.4.0

--- a/python/bruninga/ax25_fsk_mod.py
+++ b/python/bruninga/ax25_fsk_mod.py
@@ -76,7 +76,8 @@ class ax25_fsk_mod(gr.sync_block):
             return
         
         try:
-            msg = pickle.loads(msg[1])
+            msg = pickle.loads(bytes(msg[1]))
+            print("info field:", msg.info)
         except Exception as e:
             print('Bad format: Expected pickled AX25Packet')
             print(str(e))

--- a/python/bruninga/ax25_fsk_mod.py
+++ b/python/bruninga/ax25_fsk_mod.py
@@ -77,7 +77,6 @@ class ax25_fsk_mod(gr.sync_block):
         
         try:
             msg = pickle.loads(bytes(msg[1]))
-            print("info field:", msg.info)
         except Exception as e:
             print('Bad format: Expected pickled AX25Packet')
             print(str(e))

--- a/python/bruninga/packet.py
+++ b/python/bruninga/packet.py
@@ -87,8 +87,6 @@ class AX25Packet(object):
 
         # TODO: Handle various build conditions
         array += bytearray([self.control, self.protocol_id])
-        #print("packet info field:", self.info)
-        #array += bytearray(self.info, encoding='utf8')
         array += self.info.encode()
 
         return array

--- a/python/bruninga/packet.py
+++ b/python/bruninga/packet.py
@@ -87,7 +87,9 @@ class AX25Packet(object):
 
         # TODO: Handle various build conditions
         array += bytearray([self.control, self.protocol_id])
-        array += bytearray(self.info)
+        #print("packet info field:", self.info)
+        #array += bytearray(self.info, encoding='utf8')
+        array += self.info.encode()
 
         return array
 
@@ -289,7 +291,7 @@ def from_bytes(array, extended=False):
         offset += 1
 
     # The rest of the buffer is info now.
-    packet.info = array[offset:]
+    packet.info = array[offset:].decode()
 
     return packet
     

--- a/python/bruninga/str_to_aprs.py
+++ b/python/bruninga/str_to_aprs.py
@@ -62,7 +62,9 @@ class str_to_aprs(gr.sync_block):
             print('Expected tuple of (None, str)')
             return
 
-        msg = str(bytearray(msg[1]))[:-1]
+        #msg = str(bytearray(msg[1]))[:-1]
+        #print("Message:", msg)
+        msg = bytes(msg[1]).decode()[:-1]
 
         p = packet.AX25Packet()
         p.src = self.src
@@ -72,7 +74,8 @@ class str_to_aprs(gr.sync_block):
         p.protocol_id = 0xf0
         p.info = msg
 
-        out = (None, pickle.dumps(p))
+        out = (None, list(pickle.dumps(p)))
+        #print(list(pickle.dumps(p)))
         self.message_port_pub(pmt.intern('out'), pmt.to_pmt(out))
 
     def work(self, input_items, output_items):

--- a/python/bruninga/str_to_aprs.py
+++ b/python/bruninga/str_to_aprs.py
@@ -62,8 +62,6 @@ class str_to_aprs(gr.sync_block):
             print('Expected tuple of (None, str)')
             return
 
-        #msg = str(bytearray(msg[1]))[:-1]
-        #print("Message:", msg)
         msg = bytes(msg[1]).decode()[:-1]
 
         p = packet.AX25Packet()
@@ -75,7 +73,6 @@ class str_to_aprs(gr.sync_block):
         p.info = msg
 
         out = (None, list(pickle.dumps(p)))
-        #print(list(pickle.dumps(p)))
         self.message_port_pub(pmt.intern('out'), pmt.to_pmt(out))
 
     def work(self, input_items, output_items):


### PR DESCRIPTION
There was a type error when attempting to send text via the TCP source. The APRS info field was being cast as bytes and was not an acceptable pmt format.
This and the resulting cascade of parsing issues have been resolved by specifying the correct data types and conversions.